### PR TITLE
🐛 Fix: 댓글 수정, 삭제 시 비밀번호 인증 로직 수정 [#70]

### DIFF
--- a/clogging/next.config.js
+++ b/clogging/next.config.js
@@ -2,7 +2,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['firebasestorage.googleapis.com', 'picsum.photos'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/clogging/src/features/Comment/ui/CommentList.tsx
+++ b/clogging/src/features/Comment/ui/CommentList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import {
   useComments,
   useUpdateComment,
@@ -8,8 +8,10 @@ import {
 } from '../api/useComments';
 import { useUpdateReply, useDeleteReply } from '../api/Reply/useReply';
 import { CommentItem } from './CommentItem';
-import { CommentWithReplies } from '../types';
 import { useCommentListStore } from '../lib/stores/useCommentListStore';
+import { findCommentLevel } from '../utils/findCommentLevel';
+import { findParentComment } from '../utils/findParentComment';
+import { verifyPassword } from '../utils/verifyPassword';
 
 export const CommentList = ({ postId }: { postId: string }) => {
   const { data: comments, isLoading } = useComments(postId);
@@ -36,27 +38,32 @@ export const CommentList = ({ postId }: { postId: string }) => {
     setIsAdmin(adminStatus);
   }, [setIsAdmin]);
 
+  const handleReplySuccess = useCallback(() => {
+    setReplyingTo(null);
+  }, [setReplyingTo]);
+
+  const handleEditContentChange = useCallback(
+    (content: string) =>
+      setEditingComment(editingCommentId, content, editingIsPrivate),
+    [editingCommentId, editingIsPrivate, setEditingComment],
+  );
+
   if (isLoading) return <div>댓글을 불러오는 중...</div>;
   if (!comments?.length) {
     return <div className="text-gray-500">아직 댓글이 없습니다.</div>;
   }
 
-  const handleEdit = (commentId: string) => {
+  const handleEdit = async (commentId: string) => {
     const comment = findComment(comments, commentId);
     if (!comment) return;
 
-    if (comment.author === '관리자' || isAdmin) {
+    if (isAdmin) {
       setEditingComment(commentId, comment.content, comment.isPrivate);
       return;
     }
 
-    const password = prompt('비밀번호를 입력해주세요.');
-    if (!password) return;
-
-    if (password !== comment.password) {
-      alert('비밀번호가 일치하지 않습니다.');
-      return;
-    }
+    const isVerified = await verifyPassword(comment, '수정', isAdmin);
+    if (!isVerified) return;
 
     setEditingComment(commentId, comment.content, comment.isPrivate);
   };
@@ -65,31 +72,17 @@ export const CommentList = ({ postId }: { postId: string }) => {
     const comment = findComment(comments, commentId);
     if (!comment) return;
 
-    // CommentItem에서 받은 댓글이 몇 번째 depth인지 찾기
-    const findCommentLevel = (commentId: string): number => {
-      // 최상위 댓글인 경우
-      const isTopLevel = comments.find((c) => c.id === commentId);
-      if (isTopLevel) return 0;
+    // const isVerified = await verifyPassword(comment, '수정 완료', isAdmin);
+    // if (!isVerified) return;
 
-      // 답글인 경우
-      for (const comment of comments) {
-        const reply = comment.replies?.find((r) => r.id === commentId);
-        if (reply) return 1;
-      }
-      return 0;
-    };
-
-    const level = findCommentLevel(commentId);
+    const level = findCommentLevel(commentId, comments);
     console.log('댓글/답글 레벨:', level);
 
     try {
       if (level > 0) {
         // 답글인 경우
         // 부모 댓글 ID 찾기
-        const parentComment = comments.find((comment) =>
-          comment.replies?.some((reply) => reply.id === commentId),
-        );
-
+        const parentComment = findParentComment(commentId, comments);
         if (!parentComment) {
           throw new Error('부모 댓글을 찾을 수 없습니다.');
         }
@@ -115,7 +108,7 @@ export const CommentList = ({ postId }: { postId: string }) => {
       resetEditingState();
     } catch (error) {
       console.error('수정 실패:', error);
-      alert('수정에 실패했습니다.');
+      alert(error instanceof Error ? error.message : '수정에 실패했습니다.');
     }
   };
 
@@ -123,71 +116,14 @@ export const CommentList = ({ postId }: { postId: string }) => {
     const comment = findComment(comments, commentId);
     if (!comment) return;
 
-    // CommentItem에서 받은 댓글이 몇 번째 depth인지 찾기
-    const findCommentLevel = (commentId: string): number => {
-      const isTopLevel = comments.find((c) => c.id === commentId);
-      if (isTopLevel) return 0;
+    const isVerified = await verifyPassword(comment, '삭제', isAdmin);
+    if (!isVerified) return;
 
-      for (const comment of comments) {
-        const reply = comment.replies?.find((r) => r.id === commentId);
-        if (reply) return 1;
-      }
-      return 0;
-    };
-
-    const level = findCommentLevel(commentId);
-
-    if (comment.author === '관리자' || isAdmin) {
-      const confirmDelete = window.confirm('정말로 삭제하시겠습니까?');
-      if (!confirmDelete) return;
-
-      try {
-        if (level > 0) {
-          // 답글 삭제
-          const parentComment = comments.find((comment) =>
-            comment.replies?.some((reply) => reply.id === commentId),
-          );
-
-          if (!parentComment) {
-            throw new Error('부모 댓글을 찾을 수 없습니다.');
-          }
-
-          await deleteReply.mutateAsync({
-            postId,
-            commentId: parentComment.id,
-            replyId: commentId,
-            password: comment.password,
-          });
-        } else {
-          // 일반 댓글 삭제
-          await deleteComment.mutateAsync({
-            postId,
-            commentId,
-            password: comment.password,
-          });
-        }
-      } catch (error) {
-        console.error('삭제 실패:', error);
-        alert('삭제에 실패했습니다.');
-      }
-      return;
-    }
-
-    const password = prompt('삭제를 위해 비밀번호를 입력해주세요.');
-    if (!password) return;
-
-    if (password !== comment.password) {
-      alert('비밀번호가 일치하지 않습니다.');
-      return;
-    }
+    const level = findCommentLevel(commentId, comments);
 
     try {
       if (level > 0) {
-        // 답글 삭제
-        const parentComment = comments.find((comment) =>
-          comment.replies?.some((reply) => reply.id === commentId),
-        );
-
+        const parentComment = findParentComment(commentId, comments);
         if (!parentComment) {
           throw new Error('부모 댓글을 찾을 수 없습니다.');
         }
@@ -196,29 +132,24 @@ export const CommentList = ({ postId }: { postId: string }) => {
           postId,
           commentId: parentComment.id,
           replyId: commentId,
-          password,
+          password: comment.password,
         });
       } else {
-        // 일반 댓글 삭제
         await deleteComment.mutateAsync({
           postId,
           commentId,
-          password,
+          password: comment.password,
         });
       }
     } catch (error) {
       console.error('삭제 실패:', error);
-      alert('삭제 권한이 없습니다.');
+      alert(error instanceof Error ? error.message : '삭제에 실패했습니다.');
     }
-  };
-
-  const handleReplySuccess = () => {
-    setReplyingTo(null);
   };
 
   return (
     <div className="space-y-6">
-      {comments.map((comment: CommentWithReplies) => (
+      {comments.map((comment) => (
         <CommentItem
           key={comment.id}
           comment={comment}
@@ -228,9 +159,7 @@ export const CommentList = ({ postId }: { postId: string }) => {
           editingCommentId={editingCommentId}
           editingContent={editingContent}
           editingIsPrivate={editingIsPrivate}
-          onEditContentChange={(content: string) =>
-            setEditingComment(editingCommentId, content, editingIsPrivate)
-          }
+          onEditContentChange={handleEditContentChange}
           onEditPrivateChange={(isPrivate: boolean) =>
             setEditingComment(editingCommentId, editingContent, isPrivate)
           }

--- a/clogging/src/features/Comment/utils/findCommentLevel.ts
+++ b/clogging/src/features/Comment/utils/findCommentLevel.ts
@@ -1,0 +1,18 @@
+import { CommentWithReplies } from '../types';
+
+export const findCommentLevel = (
+  commentId: string,
+  comments: CommentWithReplies[],
+): number => {
+  // 최상위 댓글인 경우
+  const isTopLevel = comments?.find((c) => c.id === commentId);
+  if (isTopLevel) return 0;
+  // 답글인 경우
+  if (comments) {
+    for (const comment of comments) {
+      const reply = comment.replies?.find((r) => r.id === commentId);
+      if (reply) return 1;
+    }
+  }
+  return 0;
+};

--- a/clogging/src/features/Comment/utils/findParentComment.ts
+++ b/clogging/src/features/Comment/utils/findParentComment.ts
@@ -1,0 +1,16 @@
+import { CommentWithReplies } from '../types';
+
+export const findParentComment = (
+  commentId: string,
+  comments: CommentWithReplies[],
+): CommentWithReplies | undefined => {
+  const parentComment = comments?.find((comment) =>
+    comment.replies?.some((reply) => reply.id === commentId),
+  );
+
+  if (!parentComment) {
+    throw new Error('부모 댓글을 찾을 수 없습니다.');
+  }
+
+  return parentComment;
+};

--- a/clogging/src/features/Comment/utils/verifyPassword.ts
+++ b/clogging/src/features/Comment/utils/verifyPassword.ts
@@ -1,0 +1,26 @@
+import { CommentWithReplies } from '../types';
+
+export const verifyPassword = async (
+  comment: CommentWithReplies,
+  action: '수정' | '삭제' | '수정 완료',
+  isAdmin: boolean,
+): Promise<boolean> => {
+  if (isAdmin) {
+    if (action === '삭제') {
+      return window.confirm('정말로 삭제하시겠습니까?');
+    }
+    return true;
+  }
+
+  const password = prompt(
+    `${action}${action === '수정 완료' ? '를' : '을'} 위해 비밀번호를 입력해주세요.`,
+  );
+  if (!password) return false;
+
+  if (password !== comment.password) {
+    alert('비밀번호가 일치하지 않습니다.');
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
조건 수정, 공통 로직 유틸리티 함수로 재사용하고 파일 분리

## 👀 관련 이슈

> 해결하려는 문제가 무엇인가요 ?
- 댓글 수정, 삭제 시 비밀번호 인증 문제

## ✨ 작업한 내용

> 작업한 내용을 적어주세요

- 댓글 수정, 삭제 시 비밀번호 인증 로직 조건 수정
- 중복 로직은 유틸리티 함수로 재사용하고 파일로 분리
close #70 
## 🌀 PR Point

> 어떤 부분을 리뷰 받았으면 좋겠나요 ?

-

## 🍰 참고사항

> 추가로 남길 메모가 있으신가요 ?

## 📷 스크린샷 또는 GIF
