### PR TITLE
Feat: 포스트 작업 페이지 구현 (2)

### DIFF
--- a/clogging/package.json
+++ b/clogging/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "firebase": "^11.0.1",
     "firebase-admin": "^12.7.0",
+    "lodash": "^4.17.21",
     "lucide-react": "^0.453.0",
     "next": "15.0.0",
     "react": "19.0.0-rc-65a56d0e-20241020",
@@ -27,6 +28,7 @@
     "react-markdown": "^9.0.1",
     "react-tooltip": "^5.28.0",
     "recharts": "^2.13.1",
+    "remark-gfm": "^4.0.0",
     "tailwind-merge": "^2.5.4",
     "zod": "^3.23.8",
     "zustand": "^5.0.0"
@@ -34,6 +36,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.9",
     "@tailwindcss/typography": "^0.5.15",
+    "@types/lodash": "^4.17.13",
     "@types/node": "^20.16.14",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18",

--- a/clogging/pnpm-lock.yaml
+++ b/clogging/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       firebase-admin:
         specifier: ^12.7.0
         version: 12.7.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       lucide-react:
         specifier: ^0.453.0
         version: 0.453.0(react@19.0.0-rc-65a56d0e-20241020)
@@ -56,6 +59,9 @@ importers:
       recharts:
         specifier: ^2.13.1
         version: 2.13.1(react-dom@19.0.0-rc-65a56d0e-20241020(react@19.0.0-rc-65a56d0e-20241020))(react@19.0.0-rc-65a56d0e-20241020)
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.0
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.5.4
@@ -72,6 +78,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.15(tailwindcss@3.4.14)
+      '@types/lodash':
+        specifier: ^4.17.13
+        version: 4.17.13
       '@types/node':
         specifier: ^20.16.14
         version: 20.16.14
@@ -867,6 +876,9 @@ packages:
   '@types/jsonwebtoken@9.0.7':
     resolution: {integrity: sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==}
 
+  '@types/lodash@4.17.13':
+    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
+
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
@@ -1432,6 +1444,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-config-next@15.0.0:
     resolution: {integrity: sha512-HFeTwCR2lFEUWmdB00WZrzaak2CvMvxici38gQknA6Bu2HPizSE4PNFGaFzr5GupjBt+SBJ/E0GIP57ZptOD3g==}
@@ -2123,8 +2139,32 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.1:
+    resolution: {integrity: sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==}
+
   mdast-util-from-markdown@2.0.2:
     resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.0.0:
+    resolution: {integrity: sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.0.0:
+    resolution: {integrity: sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -2153,6 +2193,27 @@ packages:
 
   micromark-core-commonmark@2.0.1:
     resolution: {integrity: sha512-CUQyKr1e///ZODyD1U3xit6zXwy1a8q2a1S1HKtIlmgvurrEpaw/Y9y6KSIbF8P59cn/NjzHyO+Q2fAyYLQrAA==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.0:
+    resolution: {integrity: sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.0:
     resolution: {integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==}
@@ -2560,11 +2621,17 @@ packages:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
 
+  remark-gfm@4.0.0:
+    resolution: {integrity: sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.1:
     resolution: {integrity: sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3956,6 +4023,8 @@ snapshots:
     dependencies:
       '@types/node': 20.16.14
 
+  '@types/lodash@4.17.13': {}
+
   '@types/long@4.0.2':
     optional: true
 
@@ -4632,6 +4701,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-config-next@15.0.0(eslint@8.57.1)(typescript@5.6.3):
     dependencies:
@@ -5529,6 +5600,15 @@ snapshots:
     dependencies:
       react: 19.0.0-rc-65a56d0e-20241020
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.1
+
   mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -5543,6 +5623,63 @@ snapshots:
       micromark-util-symbol: 2.0.0
       micromark-util-types: 2.0.0
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.1
+      micromark-util-character: 2.1.0
+
+  mdast-util-gfm-footnote@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.1
+      micromark-util-normalize-identifier: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.0.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.0.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5637,6 +5774,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.0
       micromark-util-subtokenize: 2.0.1
       micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.0
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.1
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-classify-character: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-table@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.1.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.0
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.0
       micromark-util-types: 2.0.0
 
   micromark-factory-destination@2.0.0:
@@ -6128,6 +6323,17 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
+  remark-gfm@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.0.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -6144,6 +6350,12 @@ snapshots:
       mdast-util-to-hast: 13.2.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.1
+      unified: 11.0.5
 
   require-directory@2.1.1: {}
 

--- a/clogging/src/app/api/posts/route.ts
+++ b/clogging/src/app/api/posts/route.ts
@@ -13,7 +13,7 @@ import { db } from '@/shared/lib/firebase';
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const pageSize = parseInt(searchParams.get('pageSize') || '10');
+    const pageSize = parseInt(searchParams.get('pageSize') || '100');
     const lastPostId = searchParams.get('lastPostId');
 
     const postsRef = collection(db, 'posts');

--- a/clogging/src/features/Post/lib/hooks/useMarkdown.ts
+++ b/clogging/src/features/Post/lib/hooks/useMarkdown.ts
@@ -1,0 +1,124 @@
+import { useState, useCallback } from 'react';
+
+interface UseMarkdownReturn {
+  text: string;
+  setText: (value: string) => void;
+  handleH1Click: () => void;
+  handleH2Click: () => void;
+  handleH3Click: () => void;
+  handleH4Click: () => void;
+  handleBoldClick: () => void;
+  handleItalicClick: () => void;
+  handleStrikeClick: () => void;
+  handleListClick: () => void;
+  handleQuoteClick: () => void;
+  handleCodeBlockClick: () => void;
+}
+
+export const useMarkdown = (initialText: string = ''): UseMarkdownReturn => {
+  const [text, setText] = useState(initialText);
+
+  const wrapSelectedText = useCallback(
+    (before: string, after: string = '') => {
+      const textarea = document.querySelector('textarea');
+      if (!textarea) return;
+
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const selectedText = text.substring(start, end);
+      const beforeText = text.substring(0, start);
+      const afterText = text.substring(end);
+
+      const newText =
+        start === end
+          ? beforeText + before + after + afterText
+          : beforeText + before + selectedText + after + afterText;
+
+      setText(newText);
+
+      setTimeout(() => {
+        textarea.focus();
+        if (start === end) {
+          textarea.selectionStart = start + before.length;
+          textarea.selectionEnd = start + before.length;
+        } else {
+          textarea.selectionStart = start + before.length;
+          textarea.selectionEnd = end + before.length;
+        }
+      }, 0);
+    },
+    [text],
+  );
+
+  const addNewLine = useCallback(
+    (prefix: string) => {
+      const textarea = document.querySelector('textarea');
+      if (!textarea) return;
+
+      const start = textarea.selectionStart;
+      const currentLine = text.substring(0, start).lastIndexOf('\n') + 1;
+      const beforeText = text.substring(0, currentLine);
+      const afterText = text.substring(currentLine);
+
+      const newLinePrefix =
+        currentLine === 0 || text.charAt(currentLine - 1) === '\n' ? '' : '\n';
+      const newText = beforeText + newLinePrefix + prefix + afterText;
+
+      setText(newText);
+
+      const newCursorPosition =
+        currentLine + newLinePrefix.length + prefix.length;
+      setTimeout(() => {
+        textarea.focus();
+        textarea.selectionStart = newCursorPosition;
+        textarea.selectionEnd = newCursorPosition;
+      }, 0);
+    },
+    [text],
+  );
+
+  const handleH1Click = useCallback(() => addNewLine('# '), [addNewLine]);
+  const handleH2Click = useCallback(() => addNewLine('## '), [addNewLine]);
+  const handleH3Click = useCallback(() => addNewLine('### '), [addNewLine]);
+  const handleH4Click = useCallback(() => addNewLine('#### '), [addNewLine]);
+
+  const handleBoldClick = useCallback(
+    () => wrapSelectedText('**', '**'),
+    [wrapSelectedText],
+  );
+
+  const handleItalicClick = useCallback(
+    () => wrapSelectedText('*', '*'),
+    [wrapSelectedText],
+  );
+
+  const handleStrikeClick = useCallback(
+    () => wrapSelectedText('~~', '~~'),
+    [wrapSelectedText],
+  );
+
+  const handleListClick = useCallback(() => addNewLine('- '), [addNewLine]);
+  const handleQuoteClick = useCallback(() => addNewLine('> '), [addNewLine]);
+
+  const handleCodeBlockClick = useCallback(() => {
+    const textarea = document.querySelector('textarea');
+    if (!textarea) return;
+
+    wrapSelectedText('```\n', '\n```');
+  }, [wrapSelectedText]);
+
+  return {
+    text,
+    setText,
+    handleH1Click,
+    handleH2Click,
+    handleH3Click,
+    handleH4Click,
+    handleBoldClick,
+    handleItalicClick,
+    handleStrikeClick,
+    handleListClick,
+    handleQuoteClick,
+    handleCodeBlockClick,
+  };
+};

--- a/clogging/src/features/Post/ui/Posting/PostEditor.tsx
+++ b/clogging/src/features/Post/ui/Posting/PostEditor.tsx
@@ -2,8 +2,10 @@
 
 import React, { useState } from 'react';
 import dynamic from 'next/dynamic';
+import remarkGfm from 'remark-gfm';
 
 import { usePostEditor } from '@/features/Post/lib/hooks/usePostEditor';
+import { useMarkdown } from '@/features/Post/lib/hooks/useMarkdown';
 import { Button } from '@/shared/ui/common/Button';
 import { useTheme } from '@/shared/providers/theme';
 import { Input } from '@/shared/ui/common/Input';
@@ -31,6 +33,25 @@ const PostEditor: React.FC = () => {
     handleImageSelect,
   } = usePostEditor();
 
+  const {
+    text: markdownText,
+    setText: setMarkdownText,
+    handleH1Click,
+    handleH2Click,
+    handleH3Click,
+    handleH4Click,
+    handleBoldClick,
+    handleItalicClick,
+    handleStrikeClick,
+    handleListClick,
+    handleQuoteClick,
+    handleCodeBlockClick,
+  } = useMarkdown(editorState.content);
+
+  React.useEffect(() => {
+    handleContentChange(markdownText);
+  }, [markdownText, handleContentChange]);
+
   const { isDarkMode } = useTheme();
   const [newTag, setNewTag] = useState('');
   const [cursorPosition, setCursorPosition] = useState(0);
@@ -56,7 +77,7 @@ const PostEditor: React.FC = () => {
       imageMarkdown +
       content.slice(cursorPosition);
 
-    handleContentChange(newContent);
+    setMarkdownText(newContent);
 
     // 커서 위치 업데이트
     setTimeout(() => {
@@ -147,34 +168,64 @@ const PostEditor: React.FC = () => {
         <div className="border rounded-lg overflow-hidden flex flex-col bg-white dark:bg-gray-800">
           <div className="bg-gray-50 dark:bg-gray-700 px-4 py-2 border-b dark:border-gray-600">
             <div className="flex gap-2">
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleH1Click}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 H1
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleH2Click}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 H2
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleH3Click}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 H3
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleH4Click}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 H4
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleBoldClick}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 B
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleItalicClick}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 I
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleStrikeClick}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 S
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleListClick}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 목록
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleQuoteClick}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 인용
               </button>
-              <button className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100">
+              <button
+                onClick={handleCodeBlockClick}
+                className="px-2 py-1 text-sm hover:bg-gray-200 dark:hover:bg-gray-600 rounded text-gray-900 dark:text-gray-100"
+              >
                 &lt;&#47;&gt;
               </button>
               <button
@@ -195,9 +246,9 @@ const PostEditor: React.FC = () => {
 
           <textarea
             ref={textareaRef}
-            value={editorState.content}
+            value={markdownText}
             onPaste={handlePaste}
-            onChange={(e) => handleContentChange(e.target.value)}
+            onChange={(e) => setMarkdownText(e.target.value)}
             className="flex-1 w-full p-4 focus:outline-none resize-none bg-transparent appearance-none border-none"
             placeholder="내용을 입력하세요!"
             style={{ backgroundColor: 'transparent' }}
@@ -207,7 +258,9 @@ const PostEditor: React.FC = () => {
         {/* 미리보기 */}
         <div className="border rounded-lg p-4 mr-4 overflow-y-auto bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
           <div className="prose dark:prose-invert max-w-none text-gray-900 dark:text-gray-200">
-            <ReactMarkdown>{editorState.content}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {markdownText}
+            </ReactMarkdown>
           </div>
         </div>
       </div>
@@ -281,6 +334,13 @@ const PostEditor: React.FC = () => {
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setNewTag(e.target.value)
               }
+              onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                  //엔터하면 태그 저장되게 동작 추가
+                  addTag();
+                  e.preventDefault();
+                }
+              }}
               placeholder="최대 5개까지 가능합니다!"
               className={`w-48 h-8 border rounded-lg focus:outline-none`}
               style={{

--- a/clogging/src/features/Post/utils/helpers.ts
+++ b/clogging/src/features/Post/utils/helpers.ts
@@ -49,6 +49,9 @@ interface PostData {
   title: string;
   content: string;
   image: string[];
+  category: string;
+  tags: string[];
+  tagIds: string[];
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
@@ -58,13 +61,25 @@ export async function createPostData(
   content: string,
   image: File | null,
   imagesToDeleteId: string[] | null,
+  category: string,
+  tags: string[],
+  tagIds: string[],
+  existingImageIds: string[] = [],
 ): Promise<PostData> {
-  const { updatedImageIds } = await uploadImage(image, [], imagesToDeleteId);
+  const { updatedImageIds } = await uploadImage(
+    image,
+    existingImageIds,
+    imagesToDeleteId || [],
+  );
+  // const { updatedImageIds } = await uploadImage(image, [], imagesToDeleteId);
 
   const postData: PostData = {
     title,
     content,
     image: updatedImageIds,
+    category,
+    tags,
+    tagIds,
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
   };

--- a/clogging/src/features/Post/utils/helpers.ts
+++ b/clogging/src/features/Post/utils/helpers.ts
@@ -71,7 +71,6 @@ export async function createPostData(
     existingImageIds,
     imagesToDeleteId || [],
   );
-  // const { updatedImageIds } = await uploadImage(image, [], imagesToDeleteId);
 
   const postData: PostData = {
     title,


### PR DESCRIPTION
## 👀 관련 이슈

> 해결하려는 문제가 무엇인가요 ?

- 중복태그 처리에 대해서 해결하고 싶습니다 !
- close #80 

## ✨ 작업한 내용

> 작업한 내용을 적어주세요

- 마크다운에디터 메뉴에 있는 마크다운 버튼들 기능 구현
- 상세 포스팅에 태그 안 달리는 문제 해결

## 🌀 PR Point

> 어떤 부분을 리뷰 받았으면 좋겠나요 ?

- 포스팅 테스트하시고 추가한 태그가 잘 달리는지 확인해주세요
- 추가하려는 태그가 db에 있다면 에러가 나는데 그냥 에러처리를 할 지 고민입니다
- 원래 피그마 상 계획은 db 상에 저장되어 있는 태그들이 입력한 글자와 일부 일치하면 보여서 선택할 수 있는 기능이 있습니다

## 🍰 참고사항

> 추가로 남길 메모가 있으신가요 ?

- 상세포스팅의 마크다운 적용은 아직 안 됩니다! 이 작업 이후로 시작할 예정입니다,,,
- 태그가 db 상에 이미 중복되어있으면 에러나요! 일단은 파이어베이스의 tags 컬렉션에 중복되지 않게 테스트 부탁드려용!
- 무한 렌더링 이슈 터졌어서 lodash 로 잡아줬습니다! 그 외에도 remark-gfm 설치했습니당(마크다운 lib)
### pnpm i 한 번씩 부탁드려요


## 📷 스크린샷 또는 GIF
#### [마크다운 메뉴 버튼 클릭했을 때 텍스트에 적용]
![image](https://github.com/user-attachments/assets/893bca9c-751a-4a31-a8c9-183caef4ea49)

#### [중복된 태그로 추가할 때 에러 예시]
![image](https://github.com/user-attachments/assets/e60e2450-593d-4dcf-b0e1-1f1c54ae081c)


