### PR TITLE
Fix: 다크모드에서 상세페이지 색 수정

### DIFF
--- a/clogging/src/features/Comment/ui/CommentItem.tsx
+++ b/clogging/src/features/Comment/ui/CommentItem.tsx
@@ -36,14 +36,20 @@ export const CommentItem = ({
     <div className="comment-thread">
       {/* 댓글 카드 */}
       <div
-        className={`relative ${level > 0 ? 'ml-4 pl-4 border-l border-gray-200' : ''}`}
+        className={`relative ${level > 0 ? 'ml-4 pl-4 border-l border-gray-200 dark:border-gray-700' : ''}`}
       >
         <CardContent
-          className={`p-4 rounded-lg ${level > 0 ? 'bg-gray-50' : 'bg-white'} border`}
+          className={`p-4 rounded-lg ${
+            level > 0
+              ? 'bg-gray-50 dark:bg-gray-800'
+              : 'bg-white dark:bg-gray-900'
+          } border dark:border-gray-700`}
         >
           <CardHeader className="flex justify-between items-center mb-4">
             <CardTitle className="flex items-center gap-2">
-              <span className="font-bold">{comment.author}</span>
+              <span className="font-bold dark:text-white">
+                {comment.author}
+              </span>
               {comment.author === '관리자' && (
                 <span className="px-2 py-0.5 bg-blue-100 text-blue-800 text-sm rounded">
                   작성자
@@ -51,7 +57,7 @@ export const CommentItem = ({
               )}
             </CardTitle>
             <div className="flex items-center gap-2">
-              <time className="text-sm text-gray-500">
+              <time className="text-sm text-gray-500 dark:text-gray-400">
                 {elapsedTime(comment.createdAt)}
               </time>
               <Button
@@ -68,7 +74,7 @@ export const CommentItem = ({
               >
                 삭제
               </Button>
-              {level === 0 && ( // 최상위 댓글에만 답글 버튼 표시
+              {level === 0 && (
                 <Button
                   variant="secondary"
                   size="sm"
@@ -105,7 +111,7 @@ export const CommentItem = ({
               </div>
             </div>
           ) : (
-            <p className="text-gray-800">
+            <p className="text-gray-800 dark:text-gray-200">
               {comment.isPrivate && !isAdmin && !isEditing
                 ? '비공개 댓글입니다.'
                 : comment.content}
@@ -115,7 +121,7 @@ export const CommentItem = ({
 
         {/* 답글 작성 폼 */}
         {isReplying && (
-          <div className="mt-4 ml-4 border">
+          <div className="mt-4 ml-4 border dark:border-gray-700">
             <CommentForm
               postId={postId}
               onSuccess={() =>

--- a/clogging/src/features/Post/ui/Detail/Header.tsx
+++ b/clogging/src/features/Post/ui/Detail/Header.tsx
@@ -52,7 +52,9 @@ export const Header = ({ post }: { post: Post }) => {
   return (
     <header className="mb-8">
       <div className="flex justify-between items-start">
-        <h1 className="text-4xl font-bold mt-4">{post.title}</h1>
+        <h1 className="text-4xl font-bold mt-4 dark:text-white">
+          {post.title}
+        </h1>
         <div className="flex gap-2">
           <Button onClick={handleEdit}>수정</Button>
           <Button
@@ -66,15 +68,20 @@ export const Header = ({ post }: { post: Post }) => {
       </div>
       <div className="flex items-center gap-4 text-sm text-gray-500 mt-4">
         <Badge>{getCategoryName(post.categoryId)}</Badge>
-        <h1 className="text-4xl font-bold mt-4">{post.title}</h1>
-        <div className="flex items-center gap-4 text-sm text-gray-500">
+        <h1 className="text-4xl font-bold mt-4 dark:text-white">
+          {post.title}
+        </h1>
+        <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <Badge>{categoryName}</Badge>
           <span>|</span>
           <span>|</span>
           <time>{elapsedTime(new Date(post.createdAt).toISOString())}</time>
         </div>
         {post.tags?.map((tag) => (
-          <span key={tag} className="px-2 py-1 text-sm bg-gray-100 rounded">
+          <span
+            key={tag}
+            className="px-2 py-1 text-sm bg-gray-100 dark:bg-gray-800 rounded dark:text-gray-300"
+          >
             {tag}
           </span>
         ))}

--- a/clogging/src/features/Post/ui/Detail/Navigation.tsx
+++ b/clogging/src/features/Post/ui/Detail/Navigation.tsx
@@ -19,11 +19,15 @@ export const Navigation = ({ currentPostId }: { currentPostId: string }) => {
         className={!data?.prevPost ? 'cursor-not-allowed' : ''}
       >
         <div
-          className={`p-4 border rounded ${
-            data?.prevPost ? 'hover:bg-gray-50' : 'bg-gray-100'
+          className={`p-4 border dark:border-gray-700 rounded ${
+            data?.prevPost
+              ? 'hover:bg-gray-50 dark:hover:bg-gray-800 dark:text-white'
+              : 'bg-gray-100 dark:bg-gray-800'
           }`}
         >
-          <div className="text-sm text-gray-500 mb-4">이전 글</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            이전 글
+          </div>
           <div className="font-medium">
             {data?.prevPost ? data.prevPost.title : '이전 글이 없습니다.'}
           </div>
@@ -34,11 +38,15 @@ export const Navigation = ({ currentPostId }: { currentPostId: string }) => {
         className={!data?.nextPost ? 'cursor-not-allowed' : ''}
       >
         <div
-          className={`p-4 border rounded ${
-            data?.nextPost ? 'hover:bg-gray-50' : 'bg-gray-100'
+          className={`p-4 border dark:border-gray-700 rounded ${
+            data?.nextPost
+              ? 'hover:bg-gray-50 dark:hover:bg-gray-800 dark:text-white'
+              : 'bg-gray-100 dark:bg-gray-800'
           }`}
         >
-          <div className="text-sm text-gray-500 mb-4">다음 글</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            다음 글
+          </div>
           <div className="font-medium">
             {data?.nextPost ? data.nextPost.title : '다음 글이 없습니다.'}
           </div>


### PR DESCRIPTION
## 👀 관련 이슈

> 해결하려는 문제가 무엇인가요 ?

## ✨ 작업한 내용

> 작업한 내용을 적어주세요

- 다크모드에서 상세 포스트 페이지 색이 겹치는 부분 수정.
- 댓글 영역에서 하얗게 처리되는 부분 수정
- 페이지네이션 박스 호버 컬러 수정

## 🌀 PR Point

> 어떤 부분을 리뷰 받았으면 좋겠나요 ?

- 엉엉 아까 지옥 한 번 갔다가 바로 이슈 만들어서 수정하였습니다.. 이제 상세페이지에서 다크모드로 했을 때, 이상한 부분 없을 것 같습니다..!

## 🍰 참고사항

> 추가로 남길 메모가 있으신가요 ?

## 📷 스크린샷 또는 GIF
