### PR TITLE
Fix: 태그 5개 초과 alert 출력 #112

### DIFF
--- a/clogging/src/features/Post/ui/Posting/PostEditor.tsx
+++ b/clogging/src/features/Post/ui/Posting/PostEditor.tsx
@@ -27,7 +27,6 @@ const PostEditor: React.FC = () => {
     handleSubmit,
     handleGoBack,
     handleAddTag,
-    // handlePaste,
     handleRemoveTag,
     handleRemoveImage,
     handleImageLocalSelect,
@@ -63,6 +62,8 @@ const PostEditor: React.FC = () => {
     if (newTag && editorState.tags.length < 5) {
       handleAddTag(newTag);
       setNewTag('');
+    } else if (editorState.tags.length >= 5) {
+      alert('태그는 최대 5개까지만 추가할 수 있습니다!');
     }
   };
 
@@ -71,7 +72,6 @@ const PostEditor: React.FC = () => {
   };
 
   const insertImageToMarkdown = async (imageUrl: string) => {
-    // const imageUrl = await getImageUrl(imageId);
     const imageMarkdown = `![image](${imageUrl})\n`;
     const content = editorState.content;
     const newContent =


### PR DESCRIPTION
## 👀 관련 이슈

> 해결하려는 문제가 무엇인가요 ?

- 태그 5개 넘겨서 추가하려고 하면 alert 창으로 경고합니다!
- close #112 

## ✨ 작업한 내용

> 작업한 내용을 적어주세요

- 태그 일정 개수 이상 저장되면 alert 추가

## 🌀 PR Point

> 어떤 부분을 리뷰 받았으면 좋겠나요 ?

- 태그 5개  넘겨서 저장하려고 할 때 alert가 정상적으로 작동되는지 확인해주세요!

## 🍰 참고사항

> 추가로 남길 메모가 있으신가요 ?

## 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/9c844a1b-c659-4a83-a8ab-079bbd0fb108)

